### PR TITLE
Update language to be more humble and accurate

### DIFF
--- a/aboutme.md
+++ b/aboutme.md
@@ -1,14 +1,14 @@
 ---
 layout: page
 title: About Me
-subtitle: Software Engineer | AI Specialist | Technology Leader
+subtitle: Software Engineer | AI Enthusiast | Team Contributor
 ---
 
 <div class="about-intro">
   <div class="intro-content">
     <h2>Hello! I'm Jan-Eric Gaidusch 👋</h2>
     <p class="intro-text">
-      I'm a passionate <strong>Senior Software Engineer</strong> with over <strong>8 years of hands-on experience</strong> in software development and IT operations across multiple industries. Currently, I'm building the future of conversational AI at <strong>Parloa GmbH</strong> in Berlin, where I design and implement cutting-edge AI solutions that transform customer service.
+      I'm a passionate <strong>Senior Software Engineer</strong> with over <strong>8 years of hands-on experience</strong> in software development and IT operations across multiple industries. Currently, I'm working on conversational AI at <strong>Parloa GmbH</strong> in Berlin, where I design and implement AI solutions for customer service.
     </p>
   </div>
 </div>
@@ -19,7 +19,7 @@ subtitle: Software Engineer | AI Specialist | Technology Leader
     <div class="expertise-card">
       <div class="expertise-icon">🤖</div>
       <h3>AI & Machine Learning</h3>
-      <p>Building RAG (Retrieval-Augmented Generation) systems, working with Large Language Models, and creating intelligent conversational AI platforms that power enterprise customer service</p>
+      <p>Working with RAG (Retrieval-Augmented Generation) systems, Large Language Models, and conversational AI platforms for enterprise customer service</p>
     </div>
     <div class="expertise-card">
       <div class="expertise-icon">⚙️</div>
@@ -33,8 +33,8 @@ subtitle: Software Engineer | AI Specialist | Technology Leader
     </div>
     <div class="expertise-card">
       <div class="expertise-icon">👥</div>
-      <h3>Technical Leadership</h3>
-      <p>Mentoring engineers, building high-performing teams, driving architectural decisions, and fostering a culture of continuous improvement</p>
+      <h3>Team Collaboration</h3>
+      <p>Contributing to team growth, supporting fellow engineers, participating in architectural discussions, and promoting continuous learning</p>
     </div>
   </div>
 </div>
@@ -48,7 +48,7 @@ subtitle: Software Engineer | AI Specialist | Technology Leader
       <div class="journey-period">2023 - Present</div>
       <div class="journey-details">
         <h4>Parloa GmbH</h4>
-        <p>Leading backend development for conversational AI platforms, building RAG systems and agent management solutions</p>
+        <p>Contributing to backend development for conversational AI platforms, working on RAG systems and agent management solutions</p>
       </div>
     </div>
 
@@ -56,7 +56,7 @@ subtitle: Software Engineer | AI Specialist | Technology Leader
       <div class="journey-period">2021 - 2023</div>
       <div class="journey-details">
         <h4>Kauz GmbH</h4>
-        <p>Head of Engineering, transforming chatbot infrastructure with cloud-native Kubernetes architecture</p>
+        <p>Head of Engineering, working on chatbot infrastructure with cloud-native Kubernetes architecture</p>
       </div>
     </div>
 
@@ -64,7 +64,7 @@ subtitle: Software Engineer | AI Specialist | Technology Leader
       <div class="journey-period">2019 - 2021</div>
       <div class="journey-details">
         <h4>Neohelden GmbH</h4>
-        <p>Building self-learning AI assistants, integrating speech technologies and multiple NLU platforms</p>
+        <p>Working on self-learning AI assistants, integrating speech technologies and multiple NLU platforms</p>
       </div>
     </div>
 

--- a/aboutme.md
+++ b/aboutme.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: About Me
-subtitle: Software Engineer | AI Enthusiast | Team Contributor
+subtitle: Software Engineer | AI Enthusiast
 ---
 
 <div class="about-intro">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: home
 title: Jan-Eric Gaidusch
-subtitle: Senior Software Engineer | AI & Backend Specialist
+subtitle: Senior Software Engineer | AI & Backend Development
 cover-img:
 - "/assets/img/big-imgs/yosemite-2019.png" : "Yosemite, California (2019)"
 - "/assets/img/big-imgs/waldmaennle-2020.png" : "Fasching, Germany (2020)"
@@ -10,10 +10,10 @@ cover-img:
 
 <div class="hero-section">
   <div class="hero-content">
-    <h2 class="hero-tagline">Building Exceptional Technology Products</h2>
+    <h2 class="hero-tagline">Building Quality Technology Products</h2>
     <p class="hero-description">
       Passionate software engineer with <strong>8+ years</strong> of hands-on experience in software development and IT operations across multiple industries.
-      Specializing in AI-driven solutions, backend architecture, and cloud-native technologies.
+      Working with AI-driven solutions, backend architecture, and cloud-native technologies.
     </p>
     <div class="hero-stats">
       <div class="stat-item">
@@ -45,21 +45,21 @@ cover-img:
       <span class="location">Berlin, Germany (Remote)</span>
     </div>
     <p class="role-description">
-      Building conversational AI platforms that power customer service automation for enterprises.
-      Specializing in RAG (Retrieval-Augmented Generation) systems and scalable AI agent management.
+      Working on conversational AI platforms for customer service automation.
+      Focusing on RAG (Retrieval-Augmented Generation) systems and scalable AI agent management.
     </p>
     <div class="role-highlights">
       <div class="highlight-item">
         <span class="highlight-icon">🤖</span>
-        <span>Designed & implemented RAG products for AI-powered customer service</span>
+        <span>Contributing to RAG product development for AI-powered customer service</span>
       </div>
       <div class="highlight-item">
         <span class="highlight-icon">🏗️</span>
-        <span>Built foundation of Agent Management Platform for scalable AI operations</span>
+        <span>Working on Agent Management Platform for scalable AI operations</span>
       </div>
       <div class="highlight-item">
         <span class="highlight-icon">⚡</span>
-        <span>Redesigned conversational platform architecture reducing latency & improving scalability</span>
+        <span>Participating in conversational platform architecture improvements for better latency & scalability</span>
       </div>
     </div>
   </div>
@@ -85,8 +85,8 @@ cover-img:
     </div>
     <div class="expertise-card">
       <div class="expertise-icon">👥</div>
-      <h3>Leadership</h3>
-      <p>Team building, mentoring, technical architecture, process optimization</p>
+      <h3>Collaboration</h3>
+      <p>Team collaboration, supporting colleagues, technical discussions, process improvement</p>
     </div>
   </div>
 </div>

--- a/skills.md
+++ b/skills.md
@@ -1,11 +1,11 @@
 ---
 layout: page
 title: Technical Skills
-subtitle: My Technology Stack & Expertise
+subtitle: My Technology Stack & Experience
 ---
 
 <div class="skills-intro">
-  <p>Throughout my 8+ years in software engineering, I've built expertise across a wide range of technologies, from AI/ML systems to cloud infrastructure. Here's my current technology stack:</p>
+  <p>Throughout my 8+ years in software engineering, I've gained solid experience across a wide range of technologies, from AI/ML systems to cloud infrastructure. Here's my current technology stack:</p>
 </div>
 
 <div class="skills-container">
@@ -19,11 +19,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured">
         <div class="skill-header">
           <h3>TypeScript</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Primary language for backend and frontend development. Building scalable enterprise applications with type safety.</p>
@@ -66,11 +66,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured">
         <div class="skill-header">
           <h3>NestJS</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Building scalable, enterprise-grade backend applications with TypeScript and dependency injection.</p>
@@ -79,11 +79,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured">
         <div class="skill-header">
           <h3>FastAPI</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">High-performance Python APIs for AI/ML services with automatic API documentation.</p>
@@ -126,11 +126,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured ai-card">
         <div class="skill-header">
           <h3>RAG Systems</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Retrieval-Augmented Generation architecture for AI applications with vector databases and semantic search.</p>
@@ -139,11 +139,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured ai-card">
         <div class="skill-header">
           <h3>Large Language Models</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Building and integrating LLM-powered solutions with prompt engineering and fine-tuning.</p>
@@ -152,11 +152,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card ai-card">
         <div class="skill-header">
           <h3>NLU Engines</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Natural Language Understanding systems for intent recognition and entity extraction.</p>
@@ -186,11 +186,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured devops-card">
         <div class="skill-header">
           <h3>Kubernetes</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Container orchestration and cloud-native deployments with custom resources and operators.</p>
@@ -199,11 +199,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card featured devops-card">
         <div class="skill-header">
           <h3>Helm Charts</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Kubernetes package management and deployment automation with templating and versioning.</p>
@@ -225,11 +225,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card devops-card">
         <div class="skill-header">
           <h3>Docker</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Containerization and microservices with multi-stage builds and optimization.</p>
@@ -246,11 +246,11 @@ subtitle: My Technology Stack & Expertise
       <div class="skill-card cloud-card">
         <div class="skill-header">
           <h3>Microsoft Azure</h3>
-          <span class="skill-badge expert">Expert</span>
+          <span class="skill-badge advanced">Proficient</span>
         </div>
         <div class="skill-level">
           <div class="skill-bar">
-            <div class="skill-progress expert"></div>
+            <div class="skill-progress advanced"></div>
           </div>
         </div>
         <p class="skill-description">Azure services, AKS, and cloud architecture with extensive production experience.</p>


### PR DESCRIPTION
## Summary
- Changed all "Expert" skill badges to "Proficient" throughout the skills page
- Updated language from "expertise" to "experience" across the site
- Replaced "Specialist" and "Leader" with "Enthusiast" and "Contributor"
- Softened action verbs to emphasize collaboration over individual achievement
- Changed phrases like "building the future" to "working on"
- Updated role descriptions to use "contributing" and "participating" instead of "leading" and "transforming"

## Motivation
The previous language used terms like "Expert" which didn't align with a humble presentation of skills and experience. This update maintains professionalism while presenting accomplishments in a more modest, collaborative tone.

## Changes
### skills.md
- All "Expert" badges → "Proficient"
- "My Technology Stack & Expertise" → "My Technology Stack & Experience"
- "built expertise" → "gained solid experience"

### aboutme.md
- "AI Specialist | Technology Leader" → "AI Enthusiast | Team Contributor"
- "building the future of conversational AI" → "working on conversational AI"
- "Building RAG systems" → "Working with RAG systems"
- "Technical Leadership" → "Team Collaboration"
- Job descriptions emphasize contribution over leadership

### index.html
- "AI & Backend Specialist" → "AI & Backend Development"
- "Building Exceptional" → "Building Quality"
- "Specializing in" → "Working with"
- "Designed & implemented" → "Contributing to"
- "Leadership" → "Collaboration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)